### PR TITLE
Implement routing between item list and item detail

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -21,6 +21,7 @@
     "react-dom": "^17.0.2",
     "react-feather": "^2.0.9",
     "react-player": "^2.9.0",
+    "react-router-dom": "^5.3.0",
     "react-scripts": "^4.0.3",
     "react-templates": "^0.6.3",
     "requirejs": "^2.3.6",

--- a/app/src/Components/App.jsx
+++ b/app/src/Components/App.jsx
@@ -1,0 +1,25 @@
+
+import { MemoryRouter, Switch, Route } from "react-router-dom";
+
+import Talks from "./Talks";
+import ItemDetail from "./ItemDetail";
+
+export default function App({
+  itemId,
+}) {
+  const initialPath = itemId === undefined ? "/talks" : `/talks/${itemId}`;
+
+  return (
+    <MemoryRouter initialEntries={[initialPath]}>
+      <Switch>
+        <Route
+          path="/talks/:itemId"
+          render={({ match, location, history}) => <ItemDetail itemId={match.params.itemId} />}
+        />
+        <Route path="/talks">
+          <Talks />
+        </Route>
+      </Switch>
+    </MemoryRouter>
+  );
+};

--- a/app/src/Components/Item.jsx
+++ b/app/src/Components/Item.jsx
@@ -3,6 +3,7 @@ import Box from '@mui/material/Box';
 import ListItem from '@mui/material/ListItem';
 import IconButton from '@mui/material/IconButton';
 import { ChevronRight, Play, Volume1 } from "react-feather"
+import { useHistory } from "react-router-dom";
 
 import RectangularButton from './RectangularButton';
 import ItemMeta from "./ItemMeta";
@@ -10,6 +11,7 @@ import useBreakpoints from '../Hooks/useBreakpoints';
 
 export default function Item({
   item: {
+    id,
     title,
     desc,
     thumb,
@@ -68,7 +70,7 @@ export default function Item({
           </Box>
         )}
         <Box className="item__actions" display="flex" alignItems="center" marginLeft={1}>
-          <ItemActions isDesktop={isDesktop} video={video} audio={audio} />
+          <ItemActions isDesktop={isDesktop} video={video} audio={audio} id={id} />
         </Box>
       </Box>
     </ListItem>
@@ -77,9 +79,12 @@ export default function Item({
 
 export function ItemActions({
   isDesktop = false,
+  id,
   audio,
   video,
 }) {
+  const history = useHistory();
+
   if (isDesktop) {
     return (
       <>
@@ -100,7 +105,7 @@ export function ItemActions({
   }
 
   return (
-    <IconButton onClick={() => console.log(`go to item`)}>
+    <IconButton onClick={() => history.push(`/talks/${id}`)}>
       <ChevronRight/>
     </IconButton>
   );

--- a/app/src/Components/ItemDetail.jsx
+++ b/app/src/Components/ItemDetail.jsx
@@ -3,6 +3,7 @@ import Box from '@mui/material/Box';
 import Divider from '@mui/material/Divider';
 import { Play, Volume1, Share2 } from "react-feather"
 import * as VideoPlayer from "react-player/vimeo";
+import { Link } from 'react-router-dom';
 
 import useBreakpoints from '../Hooks/useBreakpoints';
 import Controllers_WP_REST_Request from '../Controllers/WP_REST_Request';
@@ -14,11 +15,8 @@ import ItemMeta from './ItemMeta';
 import SearchInput from './SearchInput';
 import RectangularButton from './RectangularButton';
 
-const TESTING_ID = 123;
-
 export default function ItemDetail({
-  // TODO: How to get the id? Can we pass it in to the React component?
-  itemId = TESTING_ID,
+  itemId,
 }) {
   const { isDesktop } = useBreakpoints();
   const [item, setItem] = useState();
@@ -28,19 +26,11 @@ export default function ItemDetail({
   const [mode, setMode] = useState();
 
   useEffect(() => {
-    let itemIdToFetch = itemId;
-
-    if (itemIdToFetch === undefined) {
-      // TODO: Parse the URL to get the real item id?
-      const urlSearchParams = new URLSearchParams(window.location.search);
-      itemIdToFetch = urlSearchParams.get("itemId");
-    }
-
     (async () => {
       try {
         setLoading(true);
         const restRequest = new Controllers_WP_REST_Request();
-        const data = await restRequest.get( {endpoint: `items/${itemIdToFetch}`} );
+        const data = await restRequest.get( {endpoint: `items/${itemId}`} );
         setItem(data);
       } catch (error) {
         setError(error);
@@ -68,10 +58,9 @@ export default function ItemDetail({
     // Margin bottom is to account for audio player. Making sure all content is still visible with
     // the player is up.
     <Box className="itemDetail__root" padding={2} marginBottom={mode === "audio" ? 10 : 0}>
+      <Link to="/talks">{"<"} Back to talks</Link>
       {isDesktop && (
         <>
-          {/* TODO: Real href to "Talks" */}
-          <a href="#">{"<"} Back to talks</a>
           <Box display="flex" justifyContent="space-between">
             <h1 className="itemDetail__header">Talks</h1>
             {/* TODO: Think about who's responsible for search, e.g. here or a global search provider */}

--- a/app/src/index.js
+++ b/app/src/index.js
@@ -11,7 +11,7 @@ import './css/SourceList.css';
 import './css/ItemList.css';
 import './css/Filter.css';
 
-import Talks from "./Components/Talks";
+import App from "./Components/App";
 import ItemDetail from "./Components/ItemDetail";
 
 // TODO: combine and minify generated CSS
@@ -38,8 +38,9 @@ const item = document.getElementById( 'cpl_item' );
 // }
 
 if (root) {
-	ReactDOM.render( <Talks />, root );
+	ReactDOM.render(<App />, root );
 }
+
 if( item ) {
 	ReactDOM.render( <ItemDetail />, root );
 }


### PR DESCRIPTION
Use react-router to handle the routing but use in-memory routing so the
app is independent of the host's URL. Switching between list and detail
also doesn't change the URL. This means we can embed the app in
different pages with different URLs. This also should play nicely with
Tanner's implementation of iframe-based routing.

https://user-images.githubusercontent.com/11132446/137061699-b794f76a-2dfc-4caf-a536-4f9ae4cfeba8.mp4

https://user-images.githubusercontent.com/11132446/137061706-77501f0b-3ddb-421d-9137-f7afc86ac1fd.mp4


