### PR TITLE
Use persistent player in Talks

### DIFF
--- a/app/src/Components/App.jsx
+++ b/app/src/Components/App.jsx
@@ -3,6 +3,7 @@ import { MemoryRouter, Switch, Route } from "react-router-dom";
 
 import Talks from "./Talks";
 import ItemDetail from "./ItemDetail";
+import { PersistentPlayerProvider } from "../Contexts/PersistentPlayerContext";
 
 export default function App({
   itemId,
@@ -10,16 +11,18 @@ export default function App({
   const initialPath = itemId === undefined ? "/talks" : `/talks/${itemId}`;
 
   return (
-    <MemoryRouter initialEntries={[initialPath]}>
-      <Switch>
-        <Route
-          path="/talks/:itemId"
-          render={({ match, location, history}) => <ItemDetail itemId={match.params.itemId} />}
-        />
-        <Route path="/talks">
-          <Talks />
-        </Route>
-      </Switch>
-    </MemoryRouter>
+    <PersistentPlayerProvider>
+      <MemoryRouter initialEntries={[initialPath]}>
+        <Switch>
+          <Route
+            path="/talks/:itemId"
+            render={({ match, location, history}) => <ItemDetail itemId={match.params.itemId} />}
+          />
+          <Route path="/talks">
+            <Talks />
+          </Route>
+        </Switch>
+      </MemoryRouter>
+    </PersistentPlayerProvider>
   );
 };

--- a/app/src/Components/AudioPlayer.jsx
+++ b/app/src/Components/AudioPlayer.jsx
@@ -1,12 +1,20 @@
-import CardMedia from '@mui/material/CardMedia';
+import { useRef } from "react";
 import Portal from '@mui/material/Portal';
 import Drawer from '@mui/material/Drawer';
 import Box from '@mui/material/Box';
+import ReactPlayer from 'react-player';
 
 export default function AudioPlayer({
   open = false,
   src,
+  onStart,
+  onPlay,
+  onProgress,
+  onPause,
+  onEnded,
 }) {
+  const player = useRef();
+
   return (
     <Portal>
       <Drawer
@@ -27,11 +35,25 @@ export default function AudioPlayer({
           paddingX={2}
           paddingY={1}
           sx={{ backgroundColor: "black", pointerEvents: "auto" }}
+          height={66}
         >
           {open ? (
-            <CardMedia component="audio" controls src={src} sx={{ width: "100%" }}>
+            <ReactPlayer
+              ref={player}
+              controls
+              url={src}
+              width="100%"
+              height="100%"
+              onStart={onStart}
+              onPlay={onPlay}
+              onProgress={onProgress}
+              onPause={onPause}
+              onEnded={onEnded}
+              stopOnUnmount={true}
+              progressInterval={50}
+            >
               Your browser does not support the audio element.
-            </CardMedia>
+            </ReactPlayer>
           ) : null}
         </Box>
       </Drawer>

--- a/app/src/Components/Item.jsx
+++ b/app/src/Components/Item.jsx
@@ -6,27 +6,19 @@ import { ChevronRight, Play, Volume1 } from "react-feather"
 import ReactDOM from 'react-dom';
 import { useHistory } from "react-router-dom";
 
+import useBreakpoints from '../Hooks/useBreakpoints';
+import { usePersistentPlayer } from '../Contexts/PersistentPlayerContext';
 import RectangularButton from './RectangularButton';
 import ItemMeta from "./ItemMeta";
-import useBreakpoints from '../Hooks/useBreakpoints';
 import PersistentPlayer from './PersistentPlayer';
 
 export default function Item({
-  item: {
-    id,
-    title,
-    desc,
-    thumb,
-    date,
-    video,
-    audio,
-    category = [],
-  },
+  item,
   isNew,
 }) {
   const { isDesktop } = useBreakpoints();
 
-  title = title.replace( "&#8217;", "'" );
+  const displayTitle = item.title.replace( "&#8217;", "'" );
 
   return (
     <ListItem
@@ -43,8 +35,8 @@ export default function Item({
       <Box className="item__content" display="flex" flexDirection="row" width="100%">
         <Box className="item__thumb" flex={0} display="flex" alignItems="center">
           <Box sx={{ backgroundColor: "#C4C4C4" }} borderRadius={1} width={isDesktop ? 184 : 57} height={isDesktop ? 111 : 47}>
-            {video && (
-              <video width="100%" height="100%" poster={thumb || undefined}></video>
+            {item.video && (
+              <video width="100%" height="100%" poster={item.thumb || undefined}></video>
             )}
           </Box>
         </Box>
@@ -56,9 +48,9 @@ export default function Item({
           marginLeft={2}
           justifyContent={isDesktop ? "space-between" : "center"}
         >
-          <span className="item__title">{title}</span>
+          <span className="item__title">{displayTitle}</span>
           <Box marginTop={1} className="item__itemMeta">
-            <ItemMeta date={date} category={category} />
+            <ItemMeta date={item.date} category={item.category || []} />
           </Box>
         </Box>
         {!isDesktop && isNew && (
@@ -74,7 +66,7 @@ export default function Item({
           </Box>
         )}
         <Box className="item__actions" display="flex" alignItems="center" marginLeft={1}>
-          <ItemActions isDesktop={isDesktop} video={video} audio={audio} id={id} />
+          <ItemActions isDesktop={isDesktop} item={item} />
         </Box>
       </Box>
     </ListItem>
@@ -83,21 +75,24 @@ export default function Item({
 
 export function ItemActions({
   isDesktop = false,
-  id,
-  audio,
-  video,
+  item,
 }) {
+  const { passToPersistentPlayer } = usePersistentPlayer();
 
-	const playVideo = () => {
+  const playVideo = () => {
 		let player = document.getElementById('cpl_persistent_player');
+    console.log("player", player);
 		ReactDOM.unmountComponentAtNode(player);
-		ReactDOM.render(<PersistentPlayer item={ { id, video } }/>, player);
+		ReactDOM.render(<PersistentPlayer item={item}/>, player);
 	};
 
 	const playAudio = () => {
-		let player = document.getElementById('cpl_persistent_player');
-		ReactDOM.unmountComponentAtNode(player);
-		ReactDOM.render(<PersistentPlayer item={ { id, audio } }/>, player);
+		passToPersistentPlayer({
+      item,
+      mode: "audio",
+      isPlaying: true,
+      playedSeconds: 0.0,
+    });
 	};
 
   const history = useHistory();
@@ -105,13 +100,13 @@ export function ItemActions({
   if (isDesktop) {
     return (
       <>
-        {video.value && (
+        {item.video.value && (
           <RectangularButton variant="contained" leftIcon={<Play />} onClick={playVideo}>
             Play Video
           </RectangularButton>
         )}
-        {audio && (
-          <Box marginLeft={video ? 2 : 0}>
+        {item.audio && (
+          <Box marginLeft={item.video ? 2 : 0}>
             <RectangularButton variant="outlined" leftIcon={<Volume1 />} onClick={playAudio}>
               Play Audio
             </RectangularButton>
@@ -122,7 +117,7 @@ export function ItemActions({
   }
 
   return (
-    <IconButton onClick={() => history.push(`/talks/${id}`)}>
+    <IconButton onClick={() => history.push(`/talks/${item.id}`)}>
       <ChevronRight/>
     </IconButton>
   );

--- a/app/src/Components/ItemDetail.jsx
+++ b/app/src/Components/ItemDetail.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import Box from '@mui/material/Box';
 import Divider from '@mui/material/Divider';
 import { Play, Volume1, Share2 } from "react-feather"
@@ -7,6 +7,7 @@ import { Link } from 'react-router-dom';
 
 import useBreakpoints from '../Hooks/useBreakpoints';
 import Controllers_WP_REST_Request from '../Controllers/WP_REST_Request';
+import { usePersistentPlayer } from '../Contexts/PersistentPlayerContext';
 
 import LoadingIndicator from './LoadingIndicator';
 import ErrorDisplay from './ErrorDisplay';
@@ -24,7 +25,12 @@ export default function ItemDetail({
   const [error, setError] = useState();
   // Video or audio
   const [mode, setMode] = useState();
+  // Keep frequently-updated states (mainly the progress from the media player) as a ref so they
+  // don't trigger re-render.
+  const mediaState = useRef({});
+  const { isActive: persistentPlayerIsActive, passToPersistentPlayer } = usePersistentPlayer();
 
+  // Fetch the individual item when mounted.
   useEffect(() => {
     (async () => {
       try {
@@ -40,6 +46,27 @@ export default function ItemDetail({
     })();
   }, []);
 
+  // Sync some states to be possibly passed to the persistent player. These states could be gone by
+  // the time the clean up function is done during unmounting.
+  useEffect(() => {
+    mediaState.current = { ...mediaState.current, item, mode };
+  }, [item, mode])
+
+  // When unmounted, if media is still playing, hand it off to the persistent player.
+  useEffect(() => {
+    return () => {
+      if (mediaState.current.isPlaying) {
+        passToPersistentPlayer({
+          item: mediaState.current.item,
+          mode: mediaState.current.mode,
+          isPlaying: true,
+          playedSeconds: mediaState.current.playedSeconds,
+        });
+      }
+    }
+  }, [])
+
+  // If item has both video and audio, prefer video.
   useEffect(() => {
     if (!item) return;
 
@@ -144,7 +171,7 @@ export default function ItemDetail({
               <RectangularButton
                 leftIcon={<Play />}
                 onClick={() => setMode("video")}
-                disabled={!item.video || mode === "video"}
+                // disabled={!item.video || mode === "video"}
                 fullWidth
               >
                 Play Video
@@ -154,8 +181,19 @@ export default function ItemDetail({
               <RectangularButton
                 variant="outlined"
                 leftIcon={<Volume1 />}
-                onClick={() => setMode("audio")}
-                disabled={!item.audio || mode === "audio"}
+                onClick={() => {
+                  if (persistentPlayerIsActive) {
+                    passToPersistentPlayer({
+                      item: mediaState.current.item,
+                      mode: "audio",
+                      isPlaying: true,
+                      playedSeconds: 0.0,
+                    });
+                  } else {
+                    setMode("audio");
+                  }
+                }}
+                // disabled={!item.audio || mode === "audio"}
                 fullWidth
               >
                 Play Audio
@@ -180,7 +218,27 @@ export default function ItemDetail({
         </Box>
       )}
 
-      <AudioPlayer open={mode === "audio"} src={item.audio} />
+      {!persistentPlayerIsActive && (
+        <AudioPlayer
+          open={mode === "audio"}
+          src={item.audio}
+          onStart={() => {
+            mediaState.current = { ...mediaState.current, isPlaying: true };
+          }}
+          onPlay={() => {
+            mediaState.current = { ...mediaState.current, isPlaying: true };
+          }}
+          onPause={() => {
+            mediaState.current = { ...mediaState.current, isPlaying: false };
+          }}
+          onEnded={() => {
+            mediaState.current = { ...mediaState.current, isPlaying: false, isFinished: true };
+          }}
+          onProgress={progress => {
+            mediaState.current = { ...mediaState.current, playedSeconds: progress.playedSeconds };
+          }}
+        />
+      )}
     </Box>
   );
 }

--- a/app/src/Components/PersistentPlayer.jsx
+++ b/app/src/Components/PersistentPlayer.jsx
@@ -1,10 +1,8 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import Box from '@mui/material/Box';
-import Divider from '@mui/material/Divider';
 import { Play, Pause, Volume1, Share2 } from "react-feather"
 import * as VideoPlayer from "react-player/vimeo";
-import ReactPlayer from "react-player";
-import CardMedia from '@mui/material/CardMedia';
+import FilePlayer from 'react-player/file';
 import Slider from '@mui/material/Slider';
 import ReactDOM from 'react-dom';
 
@@ -13,132 +11,142 @@ import Controllers_WP_REST_Request from '../Controllers/WP_REST_Request';
 
 import LoadingIndicator from './LoadingIndicator';
 import ErrorDisplay from './ErrorDisplay';
-import AudioPlayer from './AudioPlayer';
 import ItemMeta from './ItemMeta';
-import SearchInput from './SearchInput';
 import RoundButton from './RoundButton';
 
-const TESTING_ID = 123;
-
-export default function PersistentPlayer( propItem ) {
+export default function PersistentPlayer(props) {
   const { isDesktop } = useBreakpoints();
-  const [item, setItem] = useState( propItem.item );
+  const [item, setItem] = useState(props.item);
   const [loading, setLoading] = useState(false);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [playedSeconds, setPlayedSeconds] = useState(0.0);
   const [error, setError] = useState();
+  const [duration, setDuration] = useState(0.0);
   // Video or audio
   const [mode, setMode] = useState();
-  const [playing, setPlaying] = useState( false );
-  const [progress, setProgress] = useState( 0 );
-	const [player, setPlayer] = useState();
-
-	const ref = thisPlayer => {
-		setPlayer(thisPlayer);
-	};
 
 	const closePlayer = () => {
-		let player = document.getElementById('cpl_persistent_player');
+		const player = window.top.document.getElementById('cpl_persistent_player');
 		ReactDOM.unmountComponentAtNode(player);
-    document.body.classList.remove('cpl-persistent-player');
+    window.top.document.body.classList.remove('cpl-persistent-player');
+    window.top.postMessage({
+      action: "CPL_PERSISTENT_PLAYER_CLOSED",
+    });
 	};
 
+  const playerInstance = useRef();
+
   useEffect(() => {
-    (async () => {
-      try {
-//        setLoading(true);
-        const restRequest = new Controllers_WP_REST_Request();
-        const data = await restRequest.get( {endpoint: `items/${item.id}`} );
-        setItem(data);
-      } catch (error) {
-        setError(error);
-      } finally {
-        setLoading(false);
-      }
-    })();
+    window.top.postMessage({
+      action: "CPL_PERSISTENT_PLAYER_MOUNTED",
+      item,
+    });
+
+    return () => {
+      window.top.postMessage({
+        action: "CPL_PERSISTENT_PLAYER_UNMOUNTED",
+      });
+    }
   }, []);
+
+  useEffect(() => {
+    function handleMessage(event) {
+      if (event.data.action === "CPL_HANDOVER_TO_PERSISTENT") {
+        setItem(event.data.item);
+        setMode(event.data.mode);
+        setPlayedSeconds(event.data.playedSeconds);
+        setIsPlaying(event.data.playedSeconds > 0 ? false : event.data.isPlaying);
+      }
+    }
+
+    window.top.addEventListener("message", handleMessage);
+
+    return () => {
+      window.top.removeEventListener("message", handleMessage);
+    }
+  }, [])
 
   useEffect(() => {
     if (!item) return;
 
-    document.body.classList.add('cpl-persistent-player');
-
-    if (item.video && item.video.value) {
-      setMode("video");
-    } else if (item.audio) {
-      setMode("audio");
+    if (!document.body.classList.contains("cpl-persistent-player")) {
+      document.body.classList.add('cpl-persistent-player');
     }
+
+    window.top.postMessage({
+      action: "CPL_PERSISTENT_RECEIVED_ITEM",
+      item,
+    });
   }, [item]);
 
   return loading ? (
     <LoadingIndicator />
   ) : error ? (
     <ErrorDisplay error={error} />
-  ) : (
+  ) : item ? (
     <Box className="persistentPlayer__root" padding={2}>
-
 	    <Box className="persistentPlayer__controls" display="flex" flexDirection="row">
 
-		    <RoundButton flex={0} onClick={() => setPlaying(!playing)}>{playing ? <Pause/> : <Play/>}</RoundButton>
+		    <RoundButton flex={0} onClick={() => setIsPlaying(!isPlaying)}>{isPlaying ? <Pause/> : <Play/>}</RoundButton>
 
 		    <Box className="persistentPlayer__info" flex={1} display="flex" flexDirection="column" marginLeft={2}>
 			    <span>{item.title}</span>
-			    <Slider min={0} defaultValue={0} max={1} step={.01} value={progress} onMouseUp={() => player.seekTo(progress)}
-			            onChange={(_, value) => setProgress(value)}/>
+          <Box display="flex" flexDirection="row">
+            {Math.round(playedSeconds)}
+            <Slider
+              min={0}
+              defaultValue={0}
+              max={duration}
+              step={.01}
+              value={playedSeconds}
+              onChange={(_, value) => {
+                setIsPlaying(false);
+                setPlayedSeconds(value)
+              }}
+              onChangeCommitted={(_, value) => {
+                setIsPlaying(true);
+                playerInstance.current.seekTo(playedSeconds);
+                setPlayedSeconds(value);
+              }}
+            />
+            {Math.round(duration)}
+          </Box>
 		    </Box>
 
 		    <Box flex={0} display="flex" flexDirection="column" marginLeft={2}>
-            <RoundButton onClick={() => closePlayer()}>X</RoundButton>
+          <RoundButton onClick={closePlayer}>X</RoundButton>
 		    </Box>
 
-
-
-            {mode === "video" ? (
-              <VideoPlayer
-                className="itemDetail__video"
-                // TODO: Replace with real item.video
-                url="https://player.vimeo.com/video/621748162"
-                controls={true}
-                width="100%"
-                height="100%"
-                style={{ position: "absolute", top: 0, left: 0 }}
-                playing={playing}
-              />
-            ) : (
-              <Box
-                className="itemDetail__audio"
-                display="block"
-                alignItems="center"
-                justifyContent="center"
-//                height="100%"
-//                width="100%"
-//                position="absolute"
-//                top={0}
-//                left={0}
-              >
-	              <Box
-		              className="audioPlayer__controls"
-		              paddingX={2}
-		              paddingY={1}
-		              sx={{pointerEvents: 'auto'}}
-	              >
-		              <ReactPlayer
-			              ref={ref}
-			              className="itemDetail__audio"
-			              url={item.audio}
-			              controls={true}
-			              width="100%"
-			              height="100%"
-			              playing={playing}
-			              onProgress={(state) => {console.log(state);setProgress(state.played);}}
-		              />
-		              {/*<CardMedia component="audio" controls src={item.audio} sx={{width: '300px'}} autoPlay>*/}
-			            {/*  Your browser does not support the audio element.*/}
-		              {/*</CardMedia>*/}
-
-	              </Box>
-              </Box>
-            )}
-
+        {mode === "video" ? (
+          <VideoPlayer
+            className="itemDetail__video"
+            url={item.video}
+            controls={true}
+            width="100%"
+            height="100%"
+            style={{ position: "absolute", top: 0, left: 0 }}
+            playing={true}
+          />
+        ) : (
+          <FilePlayer
+            ref={playerInstance}
+            controls={false}
+            url={item.audio}
+            width="0"
+            height="0"
+            playing={isPlaying}
+            onDuration={duration => {
+              setDuration(duration);
+              playerInstance.current.seekTo(playedSeconds, "seconds");
+              setIsPlaying(true);
+            }}
+            onProgress={progress => setPlayedSeconds(progress.playedSeconds)}
+            progressInterval={100}
+          >
+            Your browser does not support the audio element.
+          </FilePlayer>
+        )}
 	    </Box>
     </Box>
-  );
+  ) : null;
 }

--- a/app/src/Contexts/PersistentPlayerContext.js
+++ b/app/src/Contexts/PersistentPlayerContext.js
@@ -1,0 +1,91 @@
+import { createContext, useReducer, useContext, useEffect, useCallback } from "react";
+import ReactDOM from 'react-dom';
+
+import PersistentPlayer from "../Components/PersistentPlayer";
+
+const PersistentPlayerContext = createContext()
+
+const defaultState = {
+  isActive: undefined,
+  item: undefined,
+  mode: undefined,
+  isPlaying: false,
+}
+
+function reducer(state, action) {
+  switch (action.type) {
+    case "PLAYER_MOUNTED": {
+      return { ...state, item: action.item, isActive: Boolean(action.item) };
+    }
+    case "PLAYER_UNMOUNTED": {
+      return { ...state, item: undefined, isActive: false };
+    }
+    case "PLAYER_CLOSED": {
+      return { ...state, item: undefined, isActive: false };
+    }
+    case "ITEM_PERSISTED": {
+      return { ...state, item: action.item, isActive: true };
+    }
+    default: {
+      throw new Error(`Unhandled action type: ${action.type}`)
+    }
+  }
+}
+
+function PersistentPlayerProvider({children}) {
+  const [state, dispatch] = useReducer(reducer, defaultState);
+
+  useEffect(() => {
+    function handleMessage(event) {
+      if (event.data.action === "CPL_PERSISTENT_PLAYER_MOUNTED") {
+        dispatch({ type: "PLAYER_MOUNTED", item: event.data.item });
+      } else if (event.data.action === "CPL_PERSISTENT_PLAYER_MOUNTED") {
+        dispatch({ type: "PLAYER_UNMOUNTED" });
+      } else if (event.data.action === "CPL_PERSISTENT_PLAYER_CLOSED") {
+        dispatch({ type: "PLAYER_CLOSED" })
+      } else if (event.data.action === "CPL_PERSISTENT_RECEIVED_ITEM") {
+        dispatch({ type: "ITEM_PERSISTED", item: event.data.item })
+      } 
+    }
+
+    window.top.addEventListener("message", handleMessage);
+
+    return () => {
+      window.top.removeEventListener("message", handleMessage);
+    }
+  }, [])
+
+  const passToPersistentPlayer = useCallback(({ item, mode, isPlaying, playedSeconds }) => {
+    if (state.isActive !== true) {
+      const player = window.top.document.getElementById('cpl_persistent_player');
+      ReactDOM.render(<PersistentPlayer />, player);
+    }
+    
+    window.top.postMessage({
+      action: "CPL_HANDOVER_TO_PERSISTENT",
+      item,
+      mode,
+      isPlaying,
+      playedSeconds,
+    });
+  }, [])
+
+  // NOTE: you *might* need to memoize this value
+  // Learn more in http://kcd.im/optimize-context
+  const value = {
+    ...state,
+    passToPersistentPlayer,
+  }
+
+  return <PersistentPlayerContext.Provider value={value}>{children}</PersistentPlayerContext.Provider>
+}
+
+function usePersistentPlayer() {
+  const context = useContext(PersistentPlayerContext)
+  if (context === undefined) {
+    throw new Error('usePersistentPlayer must be used within a PersistentPlayerComm.Provider')
+  }
+  return context
+}
+
+export {PersistentPlayerProvider, usePersistentPlayer}

--- a/app/src/Controllers/WP_REST_Request.js
+++ b/app/src/Controllers/WP_REST_Request.js
@@ -18,8 +18,8 @@ class Controllers_WP_REST_Request extends Component {
 
 		// In dev mode, we need the whole URL. Otherwise, it'll hit localhost:<port>/page/wp-json/...
 		// which results in 404.
-		//  this.urlBase = 'https://richardellis.local/wp-json';
-		//  this.urlBase = 'https://re.local/wp-json';
+		// this.urlBase = 'https://richardellis.local/wp-json';
+		// this.urlBase = 'https://re.local/wp-json';
 		this.urlBase = '/wp-json';
 		this.namespace = 'cp-library/v1';
 	}

--- a/app/src/index.js
+++ b/app/src/index.js
@@ -15,6 +15,7 @@ import App from "./Components/App";
 import ItemDetail from "./Components/ItemDetail";
 import ItemList from './Components/ItemList';
 import ItemWidget from './Components/ItemWidget';
+import PersistentPlayer from './Components/PersistentPlayer';
 
 // TODO: combine and minify generated CSS
 
@@ -30,6 +31,7 @@ const item = document.getElementById( 'cpl_item' );
 // const player = document.getElementById( 'cpl_player' );
 const itemList = document.getElementById( 'cpl_item_list' );
 const itemWidget = document.getElementById( 'cpl_item_widget' );
+const persistentPlayer = document.getElementById( 'cpl_persistent_player' );
 // const sourceList = document.getElementById( 'cpl_source_list' );
 
 //
@@ -54,6 +56,9 @@ if (itemWidget) {
 }
 if( item ) {
 	ReactDOM.render( <ItemDetail />, root );
+}
+if (persistentPlayer) {
+	ReactDOM.render(<PersistentPlayer />, persistentPlayer);
 }
 // if( source ) {
 // 	ReactDOM.render( <App />, source );

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -5,6 +5,7 @@
 		let SELF = this;
 
 		SELF.init = function() {
+			console.log("persistentPlayer.js initializing");
 			SELF.$body = $('body');
 			SELF.$iframe = false;
 			SELF.isIframe = (window !== window.parent);
@@ -12,24 +13,53 @@
 
 			SELF.$body.on('click', 'a', SELF.handleLinkClick);
 			window.addEventListener("message", SELF.iframeMessage);
+			console.log("persistentPlayer.js initialized", {
+				body: SELF.$body,
+				iframe: SELF.$iframe,
+				isIframe: SELF.isIframe,
+			});
 		};
 
+		/**
+		 * Indicates whether the persistent player component has been mounted or not.
+		 * @returns boolean
+		 */
 		SELF.isActive = function() {
+			console.log("persistentPlayer.js isActive:", SELF.$body.hasClass('cpl-persistent-player'))
 			return SELF.$body.hasClass('cpl-persistent-player');
 		};
 
+		/**
+		 * Invoked whenever a link (<a />) is clicked anywhere in the body. If it's a first-party link,
+		 * we hijack the event.
+		 * @param {MouseEvent} e 
+		 * @returns false
+		 */
 		SELF.handleLinkClick = function(e) {
+			console.log("persistentPlayer.js handle link click", { e })
 			SELF.url = e.currentTarget.href;
 
 			// make sure this is a local link
 			if (!SELF.url.includes(window.location.hostname)) {
+				console.log("persistentPlayer.js not a local link", {
+					url: SELF.url,
+					hostname: window.location.hostname,
+				})
 				return;
 			}
 
 			return SELF.isIframe ? SELF.handleIframeClick() : SELF.handleClick();
 		};
 
+		/**
+		 * Invoked when we're in an iframe. Sends a message to the top-most iframe.
+		 * @returns false
+		 */
 		SELF.handleIframeClick = function() {
+			console.log("persistentPlayer.js handling iframe click", {
+				'action': SELF.messageAction,
+				'url'   : SELF.url,
+			});
 			window.top.postMessage({
 				'action': SELF.messageAction,
 				'url'   : SELF.url,
@@ -38,8 +68,15 @@
 			return false;
 		};
 
+		/**
+		 * Invoked when we're the top-level window. Attach a new iframe to the body whose `src` is the
+		 * destination URL.
+		 * @returns boolean
+		 */
 		SELF.handleClick = function() {
+			console.log("persistentPlayer.js handling click");
 			if ( !SELF.isActive() ) {
+				console.log("persistentPlayer.js is not active");
 				return true;
 			}
 
@@ -48,11 +85,19 @@
 
 			SELF.$iframe.on('load', SELF.iframeLoaded);
 			SELF.$iframe.attr('src', SELF.url);
+			console.log("persistentPlayer.js iframe attached")
 
 			return false;
 		};
 
+		/**
+		 * Invoked when the newly-attached iframe loaded. Remove everything outside the iframe but the
+		 * persistent player. This makes it look like the page has successfully navigated while the
+		 * player persist. A SPA-like experience as far the end-user is concerned.
+		 */
 		SELF.iframeLoaded = function() {
+			console.log("persistentPlayer.js iframe loaded");
+
 			window.history.pushState({}, '', url);
 
 			$('body > *').each(function () {
@@ -64,16 +109,27 @@
 
 				$(this).remove();
 			});
+			console.log("persistentPlayer.js stuf removed");
 		};
 
+		/**
+		 * Invoked whenever someone post a message to this window.
+		 * @param {MessageEvent} e 
+		 * @returns undefined
+		 */
 		SELF.iframeMessage = function(e) {
+			// console.log("persistentPlayer.js message received", {e})
+			// Filter out anything that we don't care about
 			if (SELF.messageAction !== e.data.action) {
+				console.log("persistentPlayer.js message ignored", e.data);
 				return;
 			}
 
 			if (SELF.isActive()) {
+				console.log("persistentPlayer.js changing iframe src", e.data.url)
 				SELF.$iframe.attr('src', e.data.url);
 			} else {
+				console.log("persistentPlayer.js changing URL", e.data.url);
 				window.location.href = e.data.url;
 			}
 		};
@@ -82,6 +138,7 @@
 	};
 
 	$(document).on('ready', function() {
+		console.log("invoking persistentPlayer.js")
 		persistentPlayer();
 	});
 


### PR DESCRIPTION
If the persistent layer is active, use that instead of the individual
player. If not, then use the individual player.

When going back to the list of talks from an individual talk, if the
audio is still playing, hand it off to the persistent player. There's a
slight kink in that transition as we only update the progress every so
often. Lowering the progress update interval can give us smoother
transition but may have performance impact. Adjust cautiously.

<PersistentPlayerProvider /> is where all the syncing and communicating
happen between the persistent player app and the consumer. It always
use the top-most window to support the iframe navigation trick.

https://user-images.githubusercontent.com/11132446/137343482-7055db44-53b7-46a2-abac-0b3e87da05bf.mp4



