### PR TITLE
Fix double persistent player when playing from an iframe

### DIFF
--- a/app/src/Components/PersistentPlayer.jsx
+++ b/app/src/Components/PersistentPlayer.jsx
@@ -69,8 +69,8 @@ export default function PersistentPlayer(props) {
   useEffect(() => {
     if (!item) return;
 
-    if (!document.body.classList.contains("cpl-persistent-player")) {
-      document.body.classList.add('cpl-persistent-player');
+    if (!window.top.document.body.classList.contains("cpl-persistent-player")) {
+      window.top.document.body.classList.add('cpl-persistent-player');
     }
 
     window.top.postMessage({

--- a/app/src/Contexts/PersistentPlayerContext.js
+++ b/app/src/Contexts/PersistentPlayerContext.js
@@ -14,8 +14,11 @@ const defaultState = {
 
 function reducer(state, action) {
   switch (action.type) {
+    case "PLAYER_ALREADY_ACTIVE": {
+      return { ...state, isActive: true };
+    }
     case "PLAYER_MOUNTED": {
-      return { ...state, item: action.item, isActive: Boolean(action.item) };
+      return { ...state, item: action.item, isActive: state.isActive || Boolean(action.item) };
     }
     case "PLAYER_UNMOUNTED": {
       return { ...state, item: undefined, isActive: false };
@@ -34,6 +37,14 @@ function reducer(state, action) {
 
 function PersistentPlayerProvider({children}) {
   const [state, dispatch] = useReducer(reducer, defaultState);
+
+  useEffect(() => {
+    const alreadyActive = window.top.document.body.classList.contains("cpl-persistent-player");
+
+    if (alreadyActive) {
+      dispatch(({ type: "PLAYER_ALREADY_ACTIVE" }))
+    }
+  }, [])
 
   useEffect(() => {
     function handleMessage(event) {
@@ -56,7 +67,7 @@ function PersistentPlayerProvider({children}) {
   }, [])
 
   const passToPersistentPlayer = useCallback(({ item, mode, isPlaying, playedSeconds }) => {
-    if (state.isActive !== true) {
+    if (!state.isActive) {
       const player = window.top.document.getElementById('cpl_persistent_player');
       ReactDOM.render(<PersistentPlayer />, player);
     }

--- a/app/src/index.js
+++ b/app/src/index.js
@@ -57,7 +57,7 @@ if (itemWidget) {
 if( item ) {
 	ReactDOM.render( <ItemDetail />, root );
 }
-if (persistentPlayer) {
+if (window === window.top && persistentPlayer) {
 	ReactDOM.render(<PersistentPlayer />, persistentPlayer);
 }
 // if( source ) {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -5,7 +5,6 @@
 		let SELF = this;
 
 		SELF.init = function() {
-			console.log("persistentPlayer.js initializing");
 			SELF.$body = $('body');
 			SELF.$iframe = false;
 			SELF.isIframe = (window !== window.parent);
@@ -13,11 +12,6 @@
 
 			SELF.$body.on('click', 'a', SELF.handleLinkClick);
 			window.addEventListener("message", SELF.iframeMessage);
-			console.log("persistentPlayer.js initialized", {
-				body: SELF.$body,
-				iframe: SELF.$iframe,
-				isIframe: SELF.isIframe,
-			});
 		};
 
 		/**
@@ -25,7 +19,6 @@
 		 * @returns boolean
 		 */
 		SELF.isActive = function() {
-			console.log("persistentPlayer.js isActive:", SELF.$body.hasClass('cpl-persistent-player'))
 			return SELF.$body.hasClass('cpl-persistent-player');
 		};
 
@@ -36,15 +29,10 @@
 		 * @returns false
 		 */
 		SELF.handleLinkClick = function(e) {
-			console.log("persistentPlayer.js handle link click", { e })
 			SELF.url = e.currentTarget.href;
 
 			// make sure this is a local link
 			if (!SELF.url.includes(window.location.hostname)) {
-				console.log("persistentPlayer.js not a local link", {
-					url: SELF.url,
-					hostname: window.location.hostname,
-				})
 				return;
 			}
 
@@ -56,10 +44,6 @@
 		 * @returns false
 		 */
 		SELF.handleIframeClick = function() {
-			console.log("persistentPlayer.js handling iframe click", {
-				'action': SELF.messageAction,
-				'url'   : SELF.url,
-			});
 			window.top.postMessage({
 				'action': SELF.messageAction,
 				'url'   : SELF.url,
@@ -74,9 +58,7 @@
 		 * @returns boolean
 		 */
 		SELF.handleClick = function() {
-			console.log("persistentPlayer.js handling click");
 			if ( !SELF.isActive() ) {
-				console.log("persistentPlayer.js is not active");
 				return true;
 			}
 
@@ -85,7 +67,6 @@
 
 			SELF.$iframe.on('load', SELF.iframeLoaded);
 			SELF.$iframe.attr('src', SELF.url);
-			console.log("persistentPlayer.js iframe attached")
 
 			return false;
 		};
@@ -96,7 +77,6 @@
 		 * player persist. A SPA-like experience as far the end-user is concerned.
 		 */
 		SELF.iframeLoaded = function() {
-			console.log("persistentPlayer.js iframe loaded");
 
 			window.history.pushState({}, '', url);
 
@@ -109,7 +89,6 @@
 
 				$(this).remove();
 			});
-			console.log("persistentPlayer.js stuf removed");
 		};
 
 		/**
@@ -118,18 +97,14 @@
 		 * @returns undefined
 		 */
 		SELF.iframeMessage = function(e) {
-			// console.log("persistentPlayer.js message received", {e})
 			// Filter out anything that we don't care about
 			if (SELF.messageAction !== e.data.action) {
-				console.log("persistentPlayer.js message ignored", e.data);
 				return;
 			}
 
 			if (SELF.isActive()) {
-				console.log("persistentPlayer.js changing iframe src", e.data.url)
 				SELF.$iframe.attr('src', e.data.url);
 			} else {
-				console.log("persistentPlayer.js changing URL", e.data.url);
 				window.location.href = e.data.url;
 			}
 		};
@@ -138,7 +113,6 @@
 	};
 
 	$(document).on('ready', function() {
-		console.log("invoking persistentPlayer.js")
 		persistentPlayer();
 	});
 


### PR DESCRIPTION
The root cause is there are multiple PersistentPlayer that got mounted
and they all listen to the same window.top messages. By preventing
persistent player from being rendered inside an iframe, we solve the
problem.