### PR TITLE
Fix persistent player becomes unresponsive in some iframe cases

### DIFF
--- a/app/src/Components/PersistentPlayer.jsx
+++ b/app/src/Components/PersistentPlayer.jsx
@@ -68,7 +68,9 @@ export default function PersistentPlayer(props) {
   }, [])
 
   useEffect(() => {
-    if (!item) return;
+    // Since item and mode are different pieces of state that are set separately, we wait until both
+    // are set.
+    if (!item || !mode) return;
 
     if (!window.top.document.body.classList.contains("cpl-persistent-player")) {
       window.top.document.body.classList.add('cpl-persistent-player');
@@ -77,8 +79,9 @@ export default function PersistentPlayer(props) {
     window.top.postMessage({
       action: "CPL_PERSISTENT_RECEIVED_ITEM",
       item,
+      mode,
     });
-  }, [item]);
+  }, [item, mode]);
 
   return loading ? (
     <LoadingIndicator />
@@ -88,7 +91,9 @@ export default function PersistentPlayer(props) {
     <Box className="persistentPlayer__root" padding={2}>
 	    <Box className="persistentPlayer__controls" display="flex" flexDirection="row">
 
-		    <RoundButton flex={0} onClick={() => setIsPlaying(!isPlaying)}>{isPlaying ? <Pause/> : <Play/>}</RoundButton>
+        <RoundButton flex={0} onClick={() => setIsPlaying(!isPlaying)}>
+          {isPlaying ? <Pause/> : <Play/>}
+        </RoundButton>
 
 		    <Box className="persistentPlayer__info" flex={1} display="flex" flexDirection="column" marginLeft={2}>
 			    <span>{item.title}</span>
@@ -153,8 +158,10 @@ export default function PersistentPlayer(props) {
             playing={isPlaying}
             onDuration={duration => {
               setDuration(duration);
-              playerInstance.current.seekTo(playedSeconds, "seconds");
-              setIsPlaying(true);
+              if (playedSeconds > 0) {
+                playerInstance.current.seekTo(playedSeconds, "seconds");
+                setIsPlaying(true);
+              }
             }}
             onProgress={progress => setPlayedSeconds(progress.playedSeconds)}
             progressInterval={100}

--- a/app/src/Contexts/PersistentPlayerContext.js
+++ b/app/src/Contexts/PersistentPlayerContext.js
@@ -18,7 +18,7 @@ function reducer(state, action) {
       return { ...state, isActive: true };
     }
     case "PLAYER_MOUNTED": {
-      return { ...state, item: action.item, isActive: state.isActive || Boolean(action.item) };
+      return { ...state, item: action.item, isActive: true };
     }
     case "PLAYER_UNMOUNTED": {
       return { ...state, item: undefined, isActive: false };
@@ -27,7 +27,7 @@ function reducer(state, action) {
       return { ...state, item: undefined, isActive: false };
     }
     case "ITEM_PERSISTED": {
-      return { ...state, item: action.item, isActive: true };
+      return { ...state, item: action.item, isActive: true, mode: action.mode };
     }
     default: {
       throw new Error(`Unhandled action type: ${action.type}`)
@@ -55,7 +55,7 @@ function PersistentPlayerProvider({children}) {
       } else if (event.data.action === "CPL_PERSISTENT_PLAYER_CLOSED") {
         dispatch({ type: "PLAYER_CLOSED" })
       } else if (event.data.action === "CPL_PERSISTENT_RECEIVED_ITEM") {
-        dispatch({ type: "ITEM_PERSISTED", item: event.data.item })
+        dispatch({ type: "ITEM_PERSISTED", item: event.data.item, mode: event.data.mode })
       } 
     }
 
@@ -79,7 +79,7 @@ function PersistentPlayerProvider({children}) {
       isPlaying,
       playedSeconds,
     });
-  }, [])
+  }, [state.isActive])
 
   // NOTE: you *might* need to memoize this value
   // Learn more in http://kcd.im/optimize-context


### PR DESCRIPTION
For some reason, when rendering the player across iframe, it causes the
existing player component to get unmounted. This unexpected unmounting
weirdly leaves behind some parts of the DOM even though the React
component behind it was already gone. This only happens in the cross-
window situation.

The main trigger for this bug seems to be a stale passToPersistentPlayer
function (stale because of not having the right dependency array). This
causes the persistent player to get re-rendered unnecessarily whenever
an item is handed off to it (because it thinks the player's not active
every time).

Root cause is still elusive but I think we're close enough.

https://user-images.githubusercontent.com/11132446/137428986-470c6c39-e641-4105-87e7-340ab9d5e061.mp4
