### PR TITLE
Fix broken relative date in Safari

### DIFF
--- a/app/src/Components/ItemMeta.jsx
+++ b/app/src/Components/ItemMeta.jsx
@@ -1,17 +1,20 @@
 import Box from '@mui/material/Box';
 import { Calendar, Tag } from "react-feather"
 import relativeDate from "tiny-relative-date";
+import { convertWPDateStringToJSDateString } from '../utils/formateDate';
 
 
 export default function ItemMeta({
   date,
   category = [],
 }) {
+  const jsCompatibleDatestring = convertWPDateStringToJSDateString(date);
+
   return (
     <>
       <Box className="itemMeta__relativeReleaseDate" display="inline-flex" alignItems="center" marginRight={2}>
         <Calendar size="1em" />
-        <Box component="span" marginLeft={1}>{relativeDate(date)}</Box>
+        <Box component="span" marginLeft={1}>{relativeDate(jsCompatibleDatestring)}</Box>
       </Box>
       {category.length > 0 && (
         <Box

--- a/app/src/utils/formateDate.js
+++ b/app/src/utils/formateDate.js
@@ -1,0 +1,5 @@
+export function convertWPDateStringToJSDateString(dateString) {
+  // TODO: Consider doing this on the BE instead to be more predictable.
+  // Change "Y-m-d h:i:s" to "Y-m-dTh:i:s"
+  return dateString.replace(' ', 'T');
+}


### PR DESCRIPTION
"YYYY-mm-dd hh:mm:ss.ssssss" returned by the API is not a valid date
string format for the `Date` constructor (at least not supported by
Safari). This results in `new Date(dateString)` returning `Invalid
Date` value in Safari. The value becomes `NaN` eventually as the lib
process the data and, by default, the string representation for that is
"over a year from now".

The narrowest gap we can close is to make it a supported format by
inserting a "T" where the space between the date and the time is. This
commit does this on the front-end as we render the date but, ideally,
the fix should be applied in the API layer.