### PR TITLE
Do not display 'Back to' link on taxonomy pages

### DIFF
--- a/includes/Templates.php
+++ b/includes/Templates.php
@@ -245,6 +245,10 @@ class Templates {
 	 */
 	public static function type_switcher() {
 
+		if( is_tax() ) {
+			return;
+		}
+
 		$type   = self::get_type();
 		$link   = '';
 		$button = '';


### PR DESCRIPTION
Do not display "Back to sermon/series" link on taxonomy pages