### PR TITLE
Add topics and scripture to item API data

### DIFF
--- a/includes/Controllers/Item.php
+++ b/includes/Controllers/Item.php
@@ -802,6 +802,8 @@ class Item extends Controller{
 				'category'   => $this->get_categories(),
 				'speakers'   => $this->get_speakers(),
 				'locations'  => $this->get_locations(),
+				'topics'     => $this->get_topics(),
+				'scripture'  => $this->get_scripture(),
 				'video'      => $this->get_video(),
 				'audio'      => $this->get_audio(),
 				'types'      => $this->get_types(),


### PR DESCRIPTION
The metadata for topics and scripture is not showing up on the sermon list item cards, due to the data not being included in the information from get_api_data().