### PR TITLE
Fix scripture removal bug

### DIFF
--- a/includes/Setup/Taxonomies/Scripture.php
+++ b/includes/Setup/Taxonomies/Scripture.php
@@ -127,6 +127,7 @@ class Scripture extends Taxonomy  {
 		<input type="hidden" name="cpl_scripture_current_selection" id="cpl-scripture-current-selection" data-value="" />
 		<input type="hidden" name="cpl_scripture_selection_level" id="cpl-scripture-selection-level" data-value="" />
 		<input type="hidden" name="cpl_scripture_current_selection_book" id="cpl-scripture-current-selection-book" data-value="" />
+		<input type="hidden" name="cpl-scripture-tag-selections[]" />
 		<script>
 			// Add available scriptures to JavaScript
 			var availableScriptures = ' . json_encode( $scriptures ) . ';
@@ -159,7 +160,7 @@ class Scripture extends Taxonomy  {
 			return;
 		}
 
-		$this->update_object_scripture( $post_id, $_POST['cpl-scripture-tag-selections'] );
+		$this->update_object_scripture( $post_id, array_filter( (array) $_POST['cpl-scripture-tag-selections'] ) );
 	}
 
 	/**


### PR DESCRIPTION
@tannerm the code for saving the scripture checks for the existence of the `cpl-scripture-tag-selections` value in the request. If it doesn't exist, no updates are made. I added a blank input with that name so that the key always appears in the request, and thus the scriptures are updated. We could modify the existing logic and remove all scripture if that key doesn't exist, but I'm worried that the scripture might be removed unintentionally that way.