### PR TITLE
Only display variations if necessary metadata is set

### DIFF
--- a/app/src/Components/Item/Player.jsx
+++ b/app/src/Components/Item/Player.jsx
@@ -419,7 +419,11 @@ export default function Player({
 						</Box>
 					{
 						hasVariations ?
-						item.variations.map((variation) => {
+						item.variations
+						.filter(variation => (
+							!!variation.audio || !!variation.video?.value || variation.speakers?.length
+						))
+						.map((variation) => {
 							return (
 								<Controls 
 									item={ variation } 

--- a/includes/Models/Item.php
+++ b/includes/Models/Item.php
@@ -430,7 +430,7 @@ class Item extends Table  {
 			'post_name' => sanitize_title( $variant->get_variation_source_label() )
 		] );
 
-		if ( cp_library()->setup->post_types->speaker_enabled() ) {
+		if ( cp_library()->setup->post_types->speaker_enabled() && isset( $item_data['speakers'] ) ) {
 			$variant->model->update_speakers( $item_data['speakers'] );
 		}
 

--- a/templates/parts/item-list.php
+++ b/templates/parts/item-list.php
@@ -53,7 +53,9 @@ if ( $item->has_variations() ) {
 			</div>
 
 			<div class="cpl-list-item--variations">
-				<?php foreach( $item->get_variations() as $variation_id ) :
+				<?php
+				$variations = $item->get_variations();
+				foreach ( $variations as $variation_id ) :
 					$post = get_post( $variation_id );
 					try {
 						$variant = new \CP_Library\Controllers\Item( get_the_ID() );
@@ -61,7 +63,17 @@ if ( $item->has_variations() ) {
 					} catch ( \CP_Library\Exception $e ) {
 						error_log( $e );
 						continue;
-					} ?>
+					}
+
+					if (
+						empty( $variant_data['audio'] ) &&
+						empty( $variant_data['video']['value'] ) &&
+						empty( $variant_data['speakers'] )
+					) {
+						continue;
+					}
+					?>
+
 					<div class="cpl-list-item--columns">
 						<div class="cpl-list-item--details">
 							<h6 class="cpl-list-item--variations--title"><?php echo $variant->get_variation_source_label(); ?></h6>


### PR DESCRIPTION
Also fixes a PHP warning when trying to save a sermon with no speakers specified in a variation.