### PR TITLE
Fix: include standalone sermons in SermonAudio import

### DIFF
--- a/includes/Adapters/SermonAudio.php
+++ b/includes/Adapters/SermonAudio.php
@@ -156,6 +156,7 @@ class SermonAudio extends Adapter {
 			'pageSize'               => $amount,
 			'broadcasterID'          => $this->get_setting( 'broadcaster_id', '' ),
 			'sortBy'                 => 'newest',
+			'requirePlaylist'        => 'false',
 			'preachedAfterTimestamp' => strtotime( $this->get_setting( 'ignore_before', 0 ) ),
 			'cache'                  => true
 		);
@@ -192,6 +193,7 @@ class SermonAudio extends Adapter {
 			'broadcasterID'          => $this->get_setting( 'broadcaster_id', '' ),
 			'sortBy'                 => 'oldest',
 			'page'                   => $batch,
+			'requirePlaylist'        => 'false',
 			'preachedAfterTimestamp' => strtotime( $this->get_setting( 'ignore_before', 0 ) ),
 			'cache'                  => true
 		);


### PR DESCRIPTION
## Summary
Sermons not in a series are not being pulled from SermonAudio. The SA import logic appears to filter by series membership, which excludes standalone sermons.

## Type
bugfix

## Source
HelpScout #119869

## Changes
```
 includes/Adapters/SermonAudio.php | 2 ++
 1 file changed, 2 insertions(+)
```

## Acceptance Criteria
Standalone sermons from SermonAudio appear in the import list and can be imported without requiring a series assignment.

## Testing Notes
- [ ] Activate plugin and verify the fix/feature works as described
- [ ] Confirm no PHP errors in debug log
- [ ] Check that no unrelated functionality is affected

---
*Automated by churchplugins-dev agent. Review carefully before merging.*