### PR TITLE
Add: Add minimum duration filter for SermonAudio import

### DIFF
--- a/includes/Adapters/Adapter.php
+++ b/includes/Adapters/Adapter.php
@@ -574,6 +574,21 @@ abstract class Adapter extends \ChurchPlugins\Utils\WP_Background_Process {
 			)
 		);
 
+		$cmb->add_field(
+			array(
+				'name'       => __( 'Minimum Duration (seconds)', 'cp-library' ),
+				'id'         => 'min_duration',
+				'type'       => 'text_small',
+				'desc'       => __( 'Skip sermons shorter than this duration (in seconds). Leave empty or 0 to import all.', 'cp-library' ),
+				'default'    => 0,
+				'attributes' => array(
+					'min'  => 0,
+					'step' => 1,
+					'type' => 'number',
+				),
+			)
+		);
+
 		$import_in_progress = get_option( "cpl_{$this->type}_adapter_import_in_progress", false );
 		$cmb->add_field(
 			array(

--- a/includes/Adapters/SermonAudio.php
+++ b/includes/Adapters/SermonAudio.php
@@ -116,7 +116,18 @@ class SermonAudio extends Adapter {
 		$speakers   = array();
 		$item_types = array();
 
+		$min_duration = absint( $this->get_setting( 'min_duration', 0 ) );
+
 		foreach ( $items as $sermon ) {
+			// Skip sermons below minimum duration threshold
+			if ( $min_duration > 0 ) {
+				$duration = $this->get_sermon_duration( $sermon );
+
+				if ( $duration > 0 && $duration < $min_duration ) {
+					continue;
+				}
+			}
+
 			$item = $this->format_item( $sermon );
 
 			$item['attachments'] = array();
@@ -299,6 +310,28 @@ class SermonAudio extends Adapter {
 		}
 
 		return $args;
+	}
+
+	/**
+	 * Get the duration of a sermon from SA API data in seconds.
+	 *
+	 * @param \stdClass $sermon The sermon API object.
+	 * @return int Duration in seconds, or 0 if unavailable.
+	 */
+	protected function get_sermon_duration( $sermon ) {
+		if ( empty( $sermon->media ) ) {
+			return 0;
+		}
+
+		if ( ! empty( $sermon->media->audio[0]->durationInSeconds ) ) {
+			return (int) $sermon->media->audio[0]->durationInSeconds;
+		}
+
+		if ( ! empty( $sermon->media->video[0]->durationInSeconds ) ) {
+			return (int) $sermon->media->video[0]->durationInSeconds;
+		}
+
+		return 0;
 	}
 
 	/**


### PR DESCRIPTION
## Summary
Add a minimum duration filter to the SermonAudio import to exclude short clips (intros, bumpers, etc.) that aren't full sermons.

## Type
feature

## Source
ClickUp backlog

## Changes
```
 includes/Adapters/Adapter.php     | 15 +++++++++++++++
 includes/Adapters/SermonAudio.php | 33 +++++++++++++++++++++++++++++++++
 2 files changed, 48 insertions(+)
```

## Acceptance Criteria
A new setting field allows specifying minimum duration in seconds. SA imports below that threshold are skipped during import.

## Testing Notes
- [ ] Activate plugin and verify the fix/feature works as described
- [ ] Confirm no PHP errors in debug log
- [ ] Check that no unrelated functionality is affected

---
*Automated by churchplugins-dev agent. Review carefully before merging.*