### PR TITLE
Fix: Download filename should use original mp3 filename

### DIFF
--- a/src/app/Components/Item/ShareButton.jsx
+++ b/src/app/Components/Item/ShareButton.jsx
@@ -40,10 +40,13 @@ export default function ShareButton({ item, variant = "outlined" }) {
 
 		const link = document.createElement('a');
 
+		// Use the original mp3 filename from the audio URL
+		const audioFilename = item.audio.split('/').pop().split('?')[0] || 'download.mp3';
+
 		if ( item.audio.search('soundcloud') ) {
 	    link.href = item.audio;
 		} else {
-	    link.href = cplVar( 'url', 'site' ) + '?item_id=' + item.originID + '&key=audio&name=' + item.title.replace(/[^a-z0-9]/gi, '_').toLowerCase() + '.mp3';
+	    link.href = cplVar( 'url', 'site' ) + '?item_id=' + item.originID + '&key=audio';
 		}
 
 		link.setAttribute(
@@ -54,7 +57,7 @@ export default function ShareButton({ item, variant = "outlined" }) {
 		// force download
 		link.setAttribute(
 			'download',
-			item.title.replace(/[^a-z0-9]/gi, '_').toLowerCase() + '.mp3',
+			audioFilename,
 		);
 
     // Append to html link element page


### PR DESCRIPTION
## Summary
When downloading a sermon audio file, the download file name should use the original mp3 filename instead of the sermon title.

## Type
bugfix

## Source
ClickUp backlog

## Changes
```
 src/app/Components/Item/ShareButton.jsx | 7 +++++--
 1 file changed, 5 insertions(+), 2 deletions(-)
```

## Acceptance Criteria
Downloaded sermon files use the original mp3 filename rather than generating one from the sermon title.

## Testing Notes
- [ ] Activate plugin and verify the fix/feature works as described
- [ ] Confirm no PHP errors in debug log
- [ ] Check that no unrelated functionality is affected

---
*Automated by churchplugins-dev agent. Review carefully before merging.*