### PR TITLE
Fix: Fix minimum duration filter bugs

### DIFF
--- a/includes/Adapters/Adapter.php
+++ b/includes/Adapters/Adapter.php
@@ -574,6 +574,21 @@ abstract class Adapter extends \ChurchPlugins\Utils\WP_Background_Process {
 			)
 		);
 
+		$cmb->add_field(
+			array(
+				'name'       => __( 'Minimum Duration (seconds)', 'cp-library' ),
+				'id'         => 'min_duration',
+				'type'       => 'text_small',
+				'desc'       => __( 'Skip sermons shorter than this duration (in seconds). Leave empty or 0 to import all.', 'cp-library' ),
+				'default'    => 0,
+				'attributes' => array(
+					'min'  => 0,
+					'step' => 1,
+					'type' => 'number',
+				),
+			)
+		);
+
 		$import_in_progress = get_option( "cpl_{$this->type}_adapter_import_in_progress", false );
 		$cmb->add_field(
 			array(

--- a/includes/Adapters/SermonAudio.php
+++ b/includes/Adapters/SermonAudio.php
@@ -116,7 +116,18 @@ class SermonAudio extends Adapter {
 		$speakers   = array();
 		$item_types = array();
 
+		$min_duration = absint( $this->get_setting( 'min_duration', 0 ) );
+
 		foreach ( $items as $sermon ) {
+			// Skip sermons below minimum duration threshold
+			if ( $min_duration > 0 ) {
+				$duration = $this->get_sermon_duration( $sermon );
+
+				if ( $duration > 0 && $duration < $min_duration ) {
+					continue;
+				}
+			}
+
 			$item = $this->format_item( $sermon );
 
 			$item['attachments'] = array();
@@ -299,6 +310,28 @@ class SermonAudio extends Adapter {
 		}
 
 		return $args;
+	}
+
+	/**
+	 * Get the duration of a sermon from SA API data in seconds.
+	 *
+	 * @param \stdClass $sermon The sermon API object.
+	 * @return int Duration in seconds, or 0 if unavailable.
+	 */
+	protected function get_sermon_duration( $sermon ) {
+		if ( empty( $sermon->media ) ) {
+			return 0;
+		}
+
+		if ( ! empty( $sermon->media->audio[0]->durationInSeconds ) ) {
+			return (int) $sermon->media->audio[0]->durationInSeconds;
+		}
+
+		if ( ! empty( $sermon->media->video[0]->durationInSeconds ) ) {
+			return (int) $sermon->media->video[0]->durationInSeconds;
+		}
+
+		return 0;
 	}
 
 	/**


### PR DESCRIPTION
## Summary
PR #135 (feature/sa-min-duration-filter) has three bugs that make the feature non-functional: (1) Uses `get_option('min_duration')` instead of `$this->get_setting('min_duration')` — CMB2 stores adapter settings in a serialized array under `cpl_sermon_audio_adapter_options`, so the setting is never actually read. (2) Uses array syntax `$sermon['duration']` but the SA API returns stdClass objects — should be `$sermon->duration`. (3) Filter is only applied in `pull()` but not in `hard_pull()` / `fetch_all_since_date()` — should be in `format_and_process()` or `is_valid_result()` to cover all import paths. Fix all three issues on the existing branch.

## Type
bugfix

## Source
PR #135 review

## Changes
```
 includes/Adapters/Adapter.php     | 15 +++++++++++++++
 includes/Adapters/SermonAudio.php | 33 +++++++++++++++++++++++++++++++++
 2 files changed, 48 insertions(+)
```

## Acceptance Criteria
(1) Setting value is retrieved via `$this->get_setting('min_duration', 0)`. (2) Sermon data accessed with object syntax `$sermon->duration` and `$sermon->mp3Duration`. (3) Duration filter runs for all import paths including hard pull and Check Now.

## Testing Notes
- [ ] Activate plugin and verify the fix/feature works as described
- [ ] Confirm no PHP errors in debug log
- [ ] Check that no unrelated functionality is affected

---
*Automated by churchplugins-dev agent. Review carefully before merging.*