### PR TITLE
Fix: Fix sermon sort order on speaker and taxonomy pages

### DIFF
--- a/includes/Filters/Types/SermonFilterManager.php
+++ b/includes/Filters/Types/SermonFilterManager.php
@@ -457,16 +457,10 @@ class SermonFilterManager extends AbstractFilterManager {
 			return;
 		}
 
-		// Apply custom sorting for specific taxonomies
-		if ( 'cpl_scripture' === $taxonomy ) {
-			// For scripture archives, we might want to sort by book order
-			// This would require additional logic to map books to a sortable order
-		} elseif ( 'cpl_season' === $taxonomy ) {
-			// For season archives, sort by date descending as default
-			if ( ! $query->get( 'orderby' ) ) {
-				$query->set( 'orderby', 'date' );
-				$query->set( 'order', 'DESC' );
-			}
+		// Sort all CP Library taxonomy archives by date descending
+		if ( ! $query->get( 'orderby' ) ) {
+			$query->set( 'orderby', 'date' );
+			$query->set( 'order', 'DESC' );
 		}
 	}
 

--- a/includes/Setup/PostTypes/Speaker.php
+++ b/includes/Setup/PostTypes/Speaker.php
@@ -381,6 +381,8 @@ class Speaker extends PostType {
 				$post_in[] = '-1';
 			}
 			$query->set( 'post__in', $post_in );
+			$query->set( 'orderby', 'date' );
+			$query->set( 'order', 'DESC' );
 		}
 	}
 }


### PR DESCRIPTION
## Summary
Sermons on speaker archive pages and taxonomy term pages are not sorted by date. They use an internal custom order meta field instead of chronological ordering. Fix requires two changes: (1) In includes/Setup/PostTypes/Speaker.php, the speaker_query() method sets post__in from get_all_items() but never sets orderby on the WP_Query. Add orderby=date and order=DESC after setting post__in. (2) In includes/Filters/Types/SermonFilterManager.php around line 460, the taxonomy archive ordering only applies orderby=date for cpl_season archives. Extend this to apply orderby=date, order=DESC for ALL CP Library taxonomy archives (cpl_topic, cpl_scripture, cpl_season, cpl_type, etc.), not just cpl_season. The speaker model get_all_items() in includes/Models/Speaker.php orders by a custom order ASC which is fine for internal use, but the WP_Query that displays the results needs to override with date ordering.

## Type
bugfix

## Source
HelpScout #120353

## Changes
```
 includes/Filters/Types/SermonFilterManager.php | 14 ++++----------
 includes/Setup/PostTypes/Speaker.php           |  2 ++
 2 files changed, 6 insertions(+), 10 deletions(-)
```

## Acceptance Criteria
1. Sermons on speaker pages are sorted by date descending (newest first). 2. Sermons on all taxonomy term archive pages (topics, scripture, season, type) are sorted by date descending. 3. No regressions to the main sermons archive page sorting. 4. Custom ordering in admin is unaffected.

## Testing Notes
- [ ] Activate plugin and verify the fix/feature works as described
- [ ] Confirm no PHP errors in debug log
- [ ] Check that no unrelated functionality is affected

---
*Automated by churchplugins-dev agent. Review carefully before merging.*