### PR TITLE
Fix: Display all scripture references on sermon detail views

### DIFF
--- a/includes/Controllers/Item.php
+++ b/includes/Controllers/Item.php
@@ -221,29 +221,33 @@ class Item extends Controller{
 		$passages = cp_library()->setup->taxonomies->scripture->get_object_passages( $this->post->ID );
 		$terms    = cp_library()->setup->taxonomies->scripture->get_object_scripture( $this->post->ID );
 
-		if ( empty( $terms ) && empty( $passages[0] ) ) {
+		if ( empty( $terms ) && empty( $passages ) ) {
 			return $return;
 		}
 
-		$term = false;
+		if ( ! empty( $passages ) ) {
+			foreach ( $passages as $passage ) {
+				$book = cp_library()->setup->taxonomies->scripture->get_book( $passage );
+				$term = get_term_by( 'name', $book, cp_library()->setup->taxonomies->scripture->taxonomy );
 
-		if ( empty( $passages[0] ) ) {
-			$term = $terms[0];
-		} else {
-			$book = cp_library()->setup->taxonomies->scripture->get_book( $passages[0] );
-			$term = get_term_by( 'name', $book, cp_library()->setup->taxonomies->scripture->taxonomy );
-		}
+				if ( ! $term || is_wp_error( $term ) ) {
+					continue;
+				}
 
-		if ( ! $term || is_wp_error( $term ) ) {
-			return false;
-		}
-
-		$terms  = [ $term ];
-
-		if ( $terms ) {
-			foreach ( $terms as $term ) {
 				$return[ $term->slug ] = [
-					'name' => empty( $passages[0] ) ? $term->name : $passages[0],
+					'name' => $passage,
+					'slug' => $term->slug,
+					'url'  => get_term_link( $term ),
+				];
+			}
+		} else {
+			foreach ( $terms as $term ) {
+				if ( ! $term || is_wp_error( $term ) ) {
+					continue;
+				}
+
+				$return[ $term->slug ] = [
+					'name' => $term->name,
 					'slug' => $term->slug,
 					'url'  => get_term_link( $term ),
 				];


### PR DESCRIPTION
## Summary
Only the first scripture reference is displayed on sermon detail views even when multiple are tagged. In includes/Controllers/Item.php, the get_scripture() method (line 211-250) fetches passages via get_object_passages() and terms via get_object_scripture() which can return multiple results, but only uses index 0 of each. Line 241 overwrites the terms array with a single element: $terms = [ $term ]. Fix this to iterate over ALL passages and terms, building the return array with each one. Reference ItemType::get_scripture() in Controllers/ItemType.php line 94 which correctly loops through all terms from get_the_terms(). Be careful to preserve the passage-to-book mapping logic (get_book() call) for each passage, not just the first.

## Type
bugfix

## Source
HelpScout #117386 / ClickUp 868j1y696

## Changes
```
 includes/Controllers/Item.php | 36 ++++++++++++++++++++----------------
 1 file changed, 20 insertions(+), 16 deletions(-)
```

## Acceptance Criteria
1. All scripture references tagged on a sermon are displayed on the frontend. 2. Scripture references still link to the correct term archive page. 3. Passage-to-book mapping still works correctly for each passage. 4. Sermons with a single scripture reference continue to work as before. 5. Sermons with no scripture references continue to return empty array.

## Testing Notes
- [ ] Activate plugin and verify the fix/feature works as described
- [ ] Confirm no PHP errors in debug log
- [ ] Check that no unrelated functionality is affected

---
*Automated by churchplugins-dev agent. Review carefully before merging.*