### PR TITLE
Backfill 1.6.2 changelog and SermonAudio CLI docs

### DIFF
--- a/documentation/advanced/integrations.md
+++ b/documentation/advanced/integrations.md
@@ -45,8 +45,39 @@ Once enabled, a "Sermon Audio" settings tab appears:
 2. Enter your API Key (found at sermonaudio.com/members)
 3. Enter your Broadcaster ID
 4. Optionally set an "Ignore Before" date to skip older sermons
-5. Click "Start full import" to begin importing sermons
-6. Configure the Update Check interval for automatic syncing of new content
+5. Optionally set a **Minimum Audio Duration** (in seconds) to skip short clips, intros, and announcements
+6. Click "Start full import" to begin importing sermons
+7. Configure the Update Check interval for automatic syncing of new content
+
+### Importing from the Command Line
+
+For scripted, scheduled, or large-broadcaster imports, CP Sermon Library provides a WP-CLI command. The command runs the same import as the admin button but synchronously, so it returns when the import is finished and exits with a real status code.
+
+```bash
+# Full import (every sermon, oldest first)
+wp cp sermonaudio import
+
+# Pull only the most recent sermons (uses the "Check Count" setting)
+wp cp sermonaudio import --recent
+
+# Pull a specific number of recent sermons
+wp cp sermonaudio import --recent=20
+
+# Preview what would be imported without writing anything
+wp cp sermonaudio import --dry-run
+
+# Stop after the first N batches (each batch is up to 100 sermons) — useful
+# for smoke tests on large broadcasters
+wp cp sermonaudio import --max-batches=2
+```
+
+Notes:
+
+- The command requires the SermonAudio adapter to be enabled and configured (API Key + Broadcaster ID).
+- `--dry-run` fetches from the SermonAudio API and reports what would be created or updated, but skips all writes — handy for verifying configuration before a full sync.
+- `--recent` mirrors the cron-based update check. It does not clear the import queue, change-detection store, or in-progress flag, so it can safely run alongside other syncs.
+- `--recent` and `--max-batches` cannot be combined.
+- Per-item output makes the command verbose on large libraries. Pipe to a log file for large runs: `wp cp sermonaudio import > import.log 2>&1`.
 
 ## YouTube Integration
 

--- a/documentation/features/settings.md
+++ b/documentation/features/settings.md
@@ -153,6 +153,7 @@ Configure your SermonAudio connection and import settings:
 - **API Key** — Your SermonAudio API key (found at sermonaudio.com/members)
 - **Broadcaster ID** — Your SermonAudio broadcaster ID
 - **Ignore Messages Before** — Optionally set a date to skip importing older sermons
+- **Minimum Audio Duration** — Skip sermons whose audio is shorter than this many seconds. Useful for filtering out intros, announcements, and short clips. Leave blank to import everything.
 - **Start full import** — Begin a full import of all sermons from SermonAudio
 - **Update Check** — How often to automatically check for new sermons (e.g., twice daily)
 - **Check Now** — Manually trigger an update check

--- a/readme.txt
+++ b/readme.txt
@@ -118,6 +118,11 @@ Go to **Messages → Settings → Messages → Filters** or **Messages → Setti
 * Change: The per-sermon visibility checkbox is now "Exclude from Main List" (default unchecked) instead of "Show in Main List" (default checked) — matching the existing Series and Service Type metaboxes.
 * New: **Tools → Migrate Visibility Settings** — converts legacy meta from older sites and preserves any sermons you previously hid by hand.
 * New: **Tools → Reset All Sermons to Visible** — one-click recovery for sites already affected by the hidden-on-import bug. Inheritance from hidden Series or Service Types is re-applied automatically.
+* New: WP-CLI command for SermonAudio imports (`wp cp sermonaudio import`) with `--dry-run`, `--recent[=count]`, and `--max-batches` options for scripted and scheduled syncs.
+* New: Minimum audio duration filter for the SermonAudio adapter — skip short clips, intros, and announcements during import by setting a threshold in the adapter settings.
+* Fix: Vimeo videos now reliably unmute on iOS using a shared helper with chained promises.
+* Fix: All scripture references now display on sermon detail views (previously only the first reference was shown in some layouts).
+* Fix: Sermon sort order is now correct on speaker pages and taxonomy archives.
 
 = 1.6.1 =
 * Fix: Speaker page message display


### PR DESCRIPTION
## Summary
- Backfills the 1.6.2 `readme.txt` changelog with the 5 entries that were missing at merge time: SermonAudio WP-CLI command, minimum audio duration filter, Vimeo iOS unmute fix, scripture display fix, and sort-order fix.
- Adds the **Minimum Audio Duration** setting to the Sermon Audio settings reference doc.
- Adds an **Importing from the Command Line** subsection to the SermonAudio integration guide covering `wp cp sermonaudio import` and its flags (`--dry-run`, `--recent[=count]`, `--max-batches`).

This is doc-only — no behavior change. The corresponding code commits are already on master (510cb9d, 23a079f). Should land before tagging 1.6.2 so the WP plugin update screen shows the complete changelog.

## Test plan
- [ ] Confirm `readme.txt` 1.6.2 changelog lists all 9 entries
- [ ] Confirm `documentation/features/settings.md` shows the Minimum Audio Duration bullet under the Sermon Audio tab
- [ ] Confirm `documentation/advanced/integrations.md` includes the WP-CLI section under SermonAudio Integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)
